### PR TITLE
add default background color to value display in color picker

### DIFF
--- a/src/styles/clay/components/color.scss
+++ b/src/styles/clay/components/color.scss
@@ -12,6 +12,7 @@
     border-radius: $base-height / 2;
     box-shadow: $box-shadow-small-components;
     display: block;
+    background: #000;
   }
 
   .picker-wrap {


### PR DESCRIPTION
Resolves #61 

nb: I'd usually use a variable for a color but this is a special case because the color picker internal functionality relies on black being the default and I didn't want it potentially being changed if the variable was updated. 