### PR TITLE
Allow items to be in multiple groups

### DIFF
--- a/src/scripts/lib/clay-config.js
+++ b/src/scripts/lib/clay-config.js
@@ -189,7 +189,7 @@ function ClayConfig(settings, config, $rootContainer, meta) {
   self.getItemsByGroup = function(group) {
     _checkBuilt('getItemsByGroup');
     return _items.filter(function(item) {
-      return item.config.groups && item.config.groups.includes(group);
+      return item.config.groups && item.config.groups.indexOf(group) > -1;
     });
   };
 

--- a/src/scripts/lib/clay-config.js
+++ b/src/scripts/lib/clay-config.js
@@ -189,7 +189,7 @@ function ClayConfig(settings, config, $rootContainer, meta) {
   self.getItemsByGroup = function(group) {
     _checkBuilt('getItemsByGroup');
     return _items.filter(function(item) {
-      return item.config.group === group;
+      return item.config.groups && item.config.groups.includes(group);
     });
   };
 

--- a/test/spec/lib/clay-config.js
+++ b/test/spec/lib/clay-config.js
@@ -292,9 +292,9 @@ describe('ClayConfig', function() {
   describe('.getItemsByGroup()', function() {
     it('it returns the correct items', function() {
       var config = fixtures.config([
-        {type: 'input', id: 'g1-0', group: 'group1'},
-        {type: 'text', id: 'g2-0', group: 'group2'},
-        {type: 'input', id: 'g1-1', group: 'group1'}
+        {type: 'input', id: 'g1-0', groups: ['group1']},
+        {type: 'text', id: 'g2-0', groups: ['group2']},
+        {type: 'input', id: 'g1-1', groups: ['group1']}
       ]);
 
       var clayConfig = fixtures.clayConfig(config);


### PR DESCRIPTION
If items are in multiple groups interesting custom function
possibilities are opened up. For example, a section could have a toggle
that shows/hides all other items in that section. With multiple groups
attaching that behavior to all special toggles becomes something like
this:

```javascript
Clay.getItemsByGroup('section-toggle').forEach(function(toggle) {
    var groups = toggle.config.groups;
    if (!groups) return;
    groups = groups.filter(function(group) { return group !== 'section-toggle'; });
    toggle.on('change', function() {
        var enabled = this.get();
        groups.forEach(function(group) {
            Clay.getItemsByGroup(group)
                .filter(function(item) { return item !== toggle; })
                .forEach(function(item) {
                    if (enabled) item.show();
                    else item.hide();
            });
        });
    }).trigger('change');
});
```

Resolves #160