### PR TITLE
Resolves #162 - data URI now loads in iframe

### DIFF
--- a/dev/emulator.html
+++ b/dev/emulator.html
@@ -5,6 +5,8 @@
     <title>Config Page Emulator</title>
   </head>
   <script>
+  // Must wait for onload for appendChild to work
+  window.onload = function () {
     function getQueryParam(variable, defaultValue) {
       var query = location.search.substring(1);
       var vars = query.split('&');
@@ -22,13 +24,26 @@
     var data = decodeURIComponent(location.hash.substring(1));
 
     // Check if we dealing with a base64 encoded URI
-    if (data && data.charAt(0) !== '<') {
-      data = window.atob(data).replace('$$RETURN_TO$$', returnTo);
-      window.location.href = 'data:text/html;base64,' + encodeURIComponent(window.btoa(data));
-    } else if (data) {
-      data = data.replace('$$RETURN_TO$$', returnTo);
-      window.location.href = 'data:text/html;charset=utf-8,' + encodeURIComponent(data);
+    if (data) {
+      if (data.charAt(0) !== '<') {
+        data = window.atob(data).replace('$$RETURN_TO$$', returnTo);
+        data = 'data:text/html;base64,' + encodeURIComponent(window.btoa(data));
+      } else {
+        data = data.replace('$$RETURN_TO$$', returnTo);
+        data = 'data:text/html;charset=utf-8,' + encodeURIComponent(data);
+      }
+      // Create a new iframe element with our data URI
+      var iframe = document.createElement("iframe");
+      iframe.src = data;
+      // Make the iframe fill the entire display
+      iframe.frameborder = "0";
+      iframe.style = `position:fixed; top:0; left:0; bottom:0; right:0; width:100%; height:100%;
+                      border:none; margin:0; padding:0; overflow:hidden; z-index:999999;`;
+      // Append iframe to body
+      document.body.appendChild(iframe);
+      
     }
+  };
   </script>
   <body>
   </body>


### PR DESCRIPTION
Resolves #162. Top level data URI navigation is now blocked in all modern browsers. By loading the passed data URI into an iframe instead, the browser will no longer block the action.